### PR TITLE
commits: Fix pulling new changes

### DIFF
--- a/backend/automation/models/projects/commits.py
+++ b/backend/automation/models/projects/commits.py
@@ -25,7 +25,7 @@ class ProjectCommits(BaseProject):
         self.commit_prefixes = config["commit-prefixes"]
 
     def pull_changes(self) -> None:
-        self.repo.remote().pull()
+        self.repo.remote().pull(rebase=True)
 
     def get_commits_to_compare(self, initial_comparison: int = 3) -> list[str]:
         """Returns SHA of commits that should be analyzed ordered from oldest


### PR DESCRIPTION
Pulling new changes failed because of divergent branches [1]. I am not exactly sure why -- if the project (in this case bpf-next) changes history of the master branch or what happend, but this should fix it.

[1] https://github.com/diffkemp/diffkemp-automation/issues/18

Resolves #18